### PR TITLE
docs: document the one-time broker elevation flow and accept fine-grained tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package allows you to run GitHub Actions on your Synology NAS. It uses the 
 
 ## Installation
 
-1. Download the package from the [Releases](https://github.com/tomgrv/github-runner-synology/releases) page.
+1. Download the package from the [Releases](https://github.com/tomgrv/synology-github-runner/releases) page.
 
 2. Open the Synology Package Center.
 
@@ -16,14 +16,27 @@ This package allows you to run GitHub Actions on your Synology NAS. It uses the 
 
 4. Follow the installation instructions.
 
-**The package will go in error state initially, but this is expected as it needs to be elevated to run properly.**
+**The package installs cleanly but stays stopped: DSM 7 does not allow unsigned packages to manage Docker containers, so it needs a one-time approval to run.**
 
-5. Elevate the package by following the instructions from the [Synology Package Builder](https://github.com/tomgrv/synology-package-builder/blob/main/doc/elevated.md)
+5. Approve the package from a root shell (SSH):
 
-6. After elevation, the package will:
-    - Download the docker image (takes a while, you shoud receive a notification from Container Manager when done)
-    - Create a Docker container in the Container Manager. This container will be read-only and named `github-runner`
-    - Behave as a regular Package, allowing you to start/stop it from the Package Center.
+    ```bash
+    sudo /var/packages/GithubRunner/scripts/elevate
+    ```
+
+    The command shows exactly what it is approving (image, container name, privileged mode, volume bindings) before doing anything. It then installs a root-owned broker restricted to managing this package's container — the package itself keeps running as its unprivileged user. See the [elevation documentation](https://github.com/tomgrv/synology-package-builder/blob/main/doc/elevated.md) for the full security model.
+
+6. After approval, the package will:
+    - Download the docker image (takes a while)
+    - Create a Docker container in the Container Manager, named `github-runner`
+    - Behave as a regular package, allowing you to start/stop it from the Package Center.
+
+The approval survives package upgrades. When an upgrade ships a new runner image, the package asks you to re-run the command above to review and approve the change. Uninstalling the package removes the container and revokes the approval entirely.
+
+## Security notes
+
+- The runner container mounts the Docker socket, which is equivalent to root access on the NAS: only register it against an organisation or repositories you trust, and prefer a fine-grained token restricted to runner registration.
+- The access token is only used to register the runner; it is stored in the package home and in the approved container profile, both readable by root and the package user only.
 
 ## Credits
 

--- a/synology/WIZARD_UIFILES/install_uifile
+++ b/synology/WIZARD_UIFILES/install_uifile
@@ -13,7 +13,7 @@
                         "validator": {
                             "allowBlank": false,
                             "minLength": 40,
-                            "maxLength": 40
+                            "maxLength": 255
                         }
                     },
                     {


### PR DESCRIPTION
## What

Companion to tomgrv/synology-package-builder#12, which replaces the elevated mode with a least-privilege root broker.

- **README installation steps rewritten**: the package now installs cleanly and stays stopped instead of going into an error state; the manual root step becomes a single reviewable `sudo /var/packages/GithubRunner/scripts/elevate` command that shows the image, container name, privileged mode and mounts before approving, and grants the package user access to one root-owned broker instead of flipping the package to `run-as: root`. Documented that the approval survives upgrades, that a new runner image requires a re-approval, and that uninstalling revokes everything.
- **Security notes added**: mounting the Docker socket is root-equivalent on the NAS; recommend fine-grained tokens scoped to runner registration.
- **Install wizard now accepts fine-grained personal access tokens**: the validator required exactly 40 characters, which rejected the more secure `github_pat_*` tokens (`maxLength` raised to 255).
- Fixed the Releases link, which pointed to a misspelled repository name (`github-runner-synology`).

## Verification

- `install_uifile` still parses as valid JSON.
- Doc-only otherwise; the behavioural change ships with the builder PR and needs a functional pass on real DSM hardware before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1PGYcSzo7GMyvgxFumZJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1PGYcSzo7GMyvgxFumZJ6)_